### PR TITLE
set 5pt page margin instead of oversized 2em book margin

### DIFF
--- a/librarian/epub/style.css
+++ b/librarian/epub/style.css
@@ -1,3 +1,6 @@
+@page {
+  margin: 5pt;
+}
 @font-face {
     font-family: "DejaVu Serif";
     font-weight: normal;
@@ -44,17 +47,8 @@ a img {
     border: 0;
 }
 
-#book-text
-{
-    margin: 2em;
-}
-
-@media amzn-kf8
-{
-   #book-text
-    {
-        margin: 0;
-    }
+#book-text {
+    margin: 0;
 }
 
 /* =================================================== */


### PR DESCRIPTION
The current 2em book margin is completely oversized. According to that page: http://wiki.mobileread.com/wiki/CSS_HowTo I suggest to change it to 5pt;
